### PR TITLE
Fix: Mixed case tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ joplin.plugins.register({
     //#region HELPERS
 
     function checkMatchingTags(noteTags: any[], layoutTags: string[]): boolean {
-      return (noteTags.findIndex(tag => layoutTags.includes(tag.title)) >= 0);
+      return (noteTags.findIndex(tag => layoutTags.includes(tag.title.toLocaleLowerCase())) >= 0);
     }
 
     function visiblePanesMatchLayout(noteVisiblePanes: any[], layout: LayoutType): boolean {


### PR DESCRIPTION
If tags are mixed case (by importing from Evernote for example), then the layout selection does not work, because the tags from the settings are converted into lower case.